### PR TITLE
DAppNode_Installer: Follow the Filesystem Hierarchy Standard of Linux.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,10 +52,10 @@ RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_
   && chmod +x /usr/local/bin/docker-compose
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 
 ADD scripts/* ./
 ADD dappnode dappnode
 ADD boot boot
 
-CMD ["/usr/src/app/generate_ISO.sh"] 
+CMD ["/opt/app/generate_ISO.sh"]

--- a/build/dappnode/scripts/dappnode_install.sh
+++ b/build/dappnode/scripts/dappnode_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DAPPNODE_DIR="/usr/src/dappnode/"
+DAPPNODE_DIR="/opt/dappnode/"
 DAPPNODE_CORE_DIR="${DAPPNODE_DIR}DNCORE/"
 LOG_DIR="${DAPPNODE_DIR}dappnode_install.log"
 
@@ -125,7 +125,7 @@ dappnode_start()
 
     # Delete dappnode_install.sh execution from rc.local if exists
     if [ -f "/etc/rc.local" ];then
-        sed -i '/\/usr\/src\/dappnode\/scripts\/dappnode_install.sh/d' /etc/rc.local 2>&1 | tee -a $LOG_DIR
+        sed -i '/\/opt\/dappnode\/scripts\/dappnode_install.sh/d' /etc/rc.local 2>&1 | tee -a $LOG_DIR
     fi
 }
 
@@ -156,7 +156,7 @@ dappnode_core_load
 echo -e "\e[32mDAppNode installed\e[0m" 2>&1 | tee -a $LOG_DIR
 dappnode_start
 
-[ ! -f "/usr/src/dappnode/iso_install.log" ] && source "${PROFILE_FILE}"
+[ ! -f "/opt/dappnode/iso_install.log" ] && source "${PROFILE_FILE}"
 
 exit 0
 

--- a/build/dappnode/scripts/dappnode_install_pre.sh
+++ b/build/dappnode/scripts/dappnode_install_pre.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GIT_BRANCH="master"
-DAPPNODE_DIR="/usr/src/dappnode"
+DAPPNODE_DIR="/opt/dappnode"
 DOCKER_PKG="docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb"
 LIBLTDL_PKG="libltdl7_2.4.6-2_amd64.deb"
 DOCKER_PATH="${DAPPNODE_DIR}/bin/docker/${DOCKER_PKG}"

--- a/build/dappnode/scripts/dappnode_uninstall.sh
+++ b/build/dappnode/scripts/dappnode_uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DAPPNODE_DIR="/usr/src/dappnode/"
+DAPPNODE_DIR="/opt/dappnode/"
 DAPPNODE_CORE_DIR="${DAPPNODE_DIR}DNCORE/"
 
 mkdir -p $DAPPNODE_DIR
@@ -24,7 +24,7 @@ docker container ls -a -q -f name=DAppNode* | xargs -I {} docker network disconn
 docker-compose -f $BIND_YML_FILE -f $IPFS_YML_FILE -f $ETHCHAIN_YML_FILE -f $ETHFORWARD_YML_FILE -f $VPN_YML_FILE -f $WAMP_YML_FILE -f $DAPPMANAGER_YML_FILE -f $ADMIN_YML_FILE down  --rmi 'all' -v
 
 # Remove dir
-rm -rf /usr/src/dappnode
+rm -rf /opt/dappnode
 
 # Remove profile file
 USER=$(cat /etc/passwd | grep 1000  | cut -f 1 -d:)

--- a/build/dappnode/scripts/rc.local
+++ b/build/dappnode/scripts/rc.local
@@ -11,6 +11,6 @@
 #
 # By default this script does nothing.
 
-/usr/src/dappnode/scripts/dappnode_install.sh
+/opt/dappnode/scripts/dappnode_install.sh
 
 exit 0

--- a/build/scripts/.dappnode_profile
+++ b/build/scripts/.dappnode_profile
@@ -9,7 +9,7 @@ export WAMP_VERSION="${WAMP_VERSION:-0.1.0}"
 export ADMIN_VERSION="${ADMIN_VERSION:-0.1.9}"
 export DAPPMANAGER_VERSION="${DAPPMANAGER_VERSION:-0.1.12}"
 
-export DAPPNODE_DIR="/usr/src/dappnode/"
+export DAPPNODE_DIR="/opt/dappnode/"
 export DAPPNODE_CORE_DIR="${DAPPNODE_DIR}DNCORE/"
 
 export BIND_YML_FILE="${DAPPNODE_CORE_DIR}docker-compose-bind.yml"

--- a/build/scripts/generate_ISO.sh
+++ b/build/scripts/generate_ISO.sh
@@ -7,16 +7,16 @@ rm -f /images/*.yml
 
 
 if [ "$BUILD" = true ]; then
-    /usr/src/app/generate_docker_images.sh
+    /opt/app/generate_docker_images.sh
 else
-    /usr/src/app/download_core.sh
+    /opt/app/download_core.sh
 fi
 
 #file generated to detectd ISO installation
 touch dappnode/iso_install.log
 
 if [ "$UBUNTU" = "18.04" ]; then
-    /usr/src/app/generate_dappnode_iso.18.04.sh
+    /opt/app/generate_dappnode_iso.18.04.sh
 else
-    /usr/src/app/generate_dappnode_iso.16.04.sh
+    /opt/app/generate_dappnode_iso.16.04.sh
 fi

--- a/build/scripts/generate_dappnode_iso.16.04.sh
+++ b/build/scripts/generate_dappnode_iso.16.04.sh
@@ -27,25 +27,25 @@ cp -r ../dappnode/* dappnode/
 
 echo "Appending the Ubuntu Server minimal preseed files with DappNode"
 echo "d-i preseed/late_command string \
-in-target mkdir -p /usr/src/dappnode ; \
-cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/ ; \
+in-target mkdir -p /opt/dappnode ; \
+cp -ar /cdrom/dappnode/* /target/opt/dappnode/ ; \
 cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local ;\
 cp -a /cdrom/dappnode/bin/docker/docker-compose-Linux-x86_64 /target/usr/local/bin/docker-compose ; \
-in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh ; \
-in-target chmod +x /usr/src/dappnode/scripts/load_docker_images.sh ; \
+in-target chmod +x /opt/dappnode/scripts/dappnode_install_pre.sh ; \
+in-target chmod +x /opt/dappnode/scripts/load_docker_images.sh ; \
 in-target chmod +x /usr/local/bin/docker-compose ; \
-in-target /usr/src/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/hwe-ubuntu-server.seed
+in-target /opt/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/hwe-ubuntu-server.seed
 
 echo "Appending the Ubuntu Server preseed files with DappNode" 
 echo "d-i preseed/late_command string \
-in-target mkdir -p /usr/src/dappnode ; \
-cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/ ; \
+in-target mkdir -p /opt/dappnode ; \
+cp -ar /cdrom/dappnode/* /target/opt/dappnode/ ; \
 cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local ;\
 cp -a /cdrom/dappnode/bin/docker/docker-compose-Linux-x86_64 /target/usr/local/bin/docker-compose ; \
-in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh; \
-in-target chmod +x /usr/src/dappnode/scripts/load_docker_images.sh ; \
+in-target chmod +x /opt/dappnode/scripts/dappnode_install_pre.sh; \
+in-target chmod +x /opt/dappnode/scripts/load_docker_images.sh ; \
 in-target chmod +x /usr/local/bin/docker-compose ; \
-in-target /usr/src/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/ubuntu-server.seed
+in-target /opt/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/ubuntu-server.seed
 
 echo "Configuring the Ubuntu boot menu for DappNode"
 rm -f boot/grub/grub.cfg

--- a/build/scripts/generate_dappnode_iso.18.04.sh
+++ b/build/scripts/generate_dappnode_iso.18.04.sh
@@ -27,25 +27,25 @@ cp -r ../dappnode/* dappnode/
 
 echo "Appending the Ubuntu Server minimal preseed files with DappNode"
 echo "d-i preseed/late_command string \
-in-target mkdir -p /usr/src/dappnode ; \
-cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/ ; \
+in-target mkdir -p /opt/dappnode ; \
+cp -ar /cdrom/dappnode/* /target/opt/dappnode/ ; \
 cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local ;\
 cp -a /cdrom/dappnode/bin/docker/docker-compose-Linux-x86_64 /target/usr/local/bin/docker-compose ; \
-in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh ; \
-in-target chmod +x /usr/src/dappnode/scripts/load_docker_images.sh ; \
+in-target chmod +x /opt/dappnode/scripts/dappnode_install_pre.sh ; \
+in-target chmod +x /opt/dappnode/scripts/load_docker_images.sh ; \
 in-target chmod +x /usr/local/bin/docker-compose ; \
-in-target /usr/src/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/hwe-ubuntu-server.seed
+in-target /opt/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/hwe-ubuntu-server.seed
 
 echo "Appending the Ubuntu Server preseed files with DappNode" 
 echo "d-i preseed/late_command string \
-in-target mkdir -p /usr/src/dappnode ; \
-cp -ar /cdrom/dappnode/* /target/usr/src/dappnode/ ; \
+in-target mkdir -p /opt/dappnode ; \
+cp -ar /cdrom/dappnode/* /target/opt/dappnode/ ; \
 cp -a /cdrom/dappnode/scripts/rc.local /target/etc/rc.local ;\
 cp -a /cdrom/dappnode/bin/docker/docker-compose-Linux-x86_64 /target/usr/local/bin/docker-compose ; \
-in-target chmod +x /usr/src/dappnode/scripts/dappnode_install_pre.sh; \
-in-target chmod +x /usr/src/dappnode/scripts/load_docker_images.sh ; \
+in-target chmod +x /opt/dappnode/scripts/dappnode_install_pre.sh; \
+in-target chmod +x /opt/dappnode/scripts/load_docker_images.sh ; \
 in-target chmod +x /usr/local/bin/docker-compose ; \
-in-target /usr/src/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/ubuntu-server.seed
+in-target /opt/dappnode/scripts/dappnode_install_pre.sh" | tee -a preseed/ubuntu-server.seed
 
 echo "Configuring the Ubuntu boot menu for DappNode"
 rm -f boot/grub/grub.cfg


### PR DESCRIPTION
The current data path is installed under /usr/src, a directory reserved
for linux kernel sources. Follow the Filesystem Hierarchy Standard
of Linux, and use /opt/dappnode instead.

Refs: https://github.com/dappnode/DAppNode/issues/39