### PR TITLE
Relocated dncore_network creation

### DIFF
--- a/build/dappnode/scripts/dappnode_install.sh
+++ b/build/dappnode/scripts/dappnode_install.sh
@@ -255,6 +255,9 @@ if [ $ARCH == "amd64" ]; then
     installExtra
 fi
 
+echo -e "\e[32mCreating dncore_network if needed...\e[0m" 2>&1 | tee -a $LOG_DIR
+docker network create --driver bridge --subnet 172.33.0.0/16 dncore_network || echo "dncore_network already exists"
+
 echo -e "\e[32mBuilding DAppNode Core if needed...\e[0m" 2>&1 | tee -a $LOG_DIR
 dappnode_core_build
 

--- a/build/dappnode/scripts/dappnode_install_pre.sh
+++ b/build/dappnode/scripts/dappnode_install_pre.sh
@@ -157,6 +157,3 @@ if [ -f /usr/src/dappnode/hotplug ]; then
         fi
     done
 fi
-
-# Only create docker network if needed
-docker network create --driver bridge --subnet 172.33.0.0/16 dncore_network || echo "dncore_network already exists"


### PR DESCRIPTION
### Creation of `dncore_network`

**Before**: was located in the `prerrequisites.sh` script which is not mandatory to install dappnode (only if you do not have docker and docker compose).

**After this PR**: create `dncore_network` when installing dappnode, to ensure the `dncore_network` will be created always