### PR TITLE
Compose up against composes with different versions

### DIFF
--- a/build/dappnode/scripts/dappnode_install.sh
+++ b/build/dappnode/scripts/dappnode_install.sh
@@ -165,7 +165,7 @@ dappnode_start() {
     # To execute `compose-up` against more than 1 compose, composes files must share compose file version (e.g 3.5)
     for comp in "${DNCORE_YMLS[@]}"; do
         docker-compose $comp up -d 2>&1 | tee -a $LOGFILE
-        echo -e "\e[32m${comp} started\e[0m" 2>&1 | tee -a $LOGFILE
+        echo "${comp} started" 2>&1 | tee -a $LOGFILE
     done
     echo -e "\e[32mDAppNode started\e[0m" 2>&1 | tee -a $LOGFILE
 

--- a/build/dappnode/scripts/dappnode_install.sh
+++ b/build/dappnode/scripts/dappnode_install.sh
@@ -160,7 +160,13 @@ addSwap() {
 dappnode_start() {
     echo -e "\e[32mDAppNode starting...\e[0m" 2>&1 | tee -a $LOGFILE
     source "${DAPPNODE_PROFILE}" >/dev/null 2>&1
-    docker-compose $DNCORE_YMLS up -d 2>&1 | tee -a $LOGFILE
+
+    # Execute `compose-up` independently
+    # To execute `compose-up` against more than 1 compose, composes files must share compose file version (e.g 3.5)
+    for comp in "${DNCORE_YMLS[@]}"; do
+        docker-compose $comp up -d 2>&1 | tee -a $LOGFILE
+        echo -e "\e[32m${comp} started\e[0m" 2>&1 | tee -a $LOGFILE
+    done
     echo -e "\e[32mDAppNode started\e[0m" 2>&1 | tee -a $LOGFILE
 
     # Show credentials to the user on login

--- a/build/dappnode/scripts/dappnode_install.sh
+++ b/build/dappnode/scripts/dappnode_install.sh
@@ -163,8 +163,8 @@ dappnode_start() {
 
     # Execute `compose-up` independently
     # To execute `compose-up` against more than 1 compose, composes files must share compose file version (e.g 3.5)
-    for comp in "${DNCORE_YMLS[@]}"; do
-        docker-compose $comp up -d 2>&1 | tee -a $LOGFILE
+    for comp in "${DNCORE_YMLS_ARRAY[@]}"; do
+        docker-compose -f $comp up -d 2>&1 | tee -a $LOGFILE
         echo "${comp} started" 2>&1 | tee -a $LOGFILE
     done
     echo -e "\e[32mDAppNode started\e[0m" 2>&1 | tee -a $LOGFILE

--- a/build/dappnode/scripts/dappnode_uninstall.sh
+++ b/build/dappnode/scripts/dappnode_uninstall.sh
@@ -18,7 +18,9 @@ uninstall() {
     docker container ls -a -q -f name=DAppNode* | xargs -I {} docker network disconnect dncore_network {}
 
     # Remove containers, volumes and images
-    docker-compose $DNCORE_YMLS down --rmi 'all' -v
+    for comp in "${DNCORE_YMLS_ARRAY[@]}"; do
+        docker-compose -f $comp down --rmi 'all' -v
+    done
 
     # Remove dncore_network
     docker network remove dncore_network || echo "dncore_network already removed"

--- a/build/dappnode/scripts/dappnode_uninstall.sh
+++ b/build/dappnode/scripts/dappnode_uninstall.sh
@@ -18,9 +18,7 @@ uninstall() {
     docker container ls -a -q -f name=DAppNode* | xargs -I {} docker network disconnect dncore_network {}
 
     # Remove containers, volumes and images
-    for comp in "${DNCORE_YMLS_ARRAY[@]}"; do
-        docker-compose -f $comp down --rmi 'all' -v
-    done
+    docker-compose $DNCORE_YMLS down --rmi 'all' -v
 
     # Remove dncore_network
     docker network remove dncore_network || echo "dncore_network already removed"

--- a/build/scripts/.dappnode_profile
+++ b/build/scripts/.dappnode_profile
@@ -11,6 +11,8 @@ export DAPPNODE_CORE_DIR="${DAPPNODE_DIR}/DNCORE"
 
 #!ISOBUILD Do not modify, variables above imported for ISO build
 DNCORE_YMLS=$(find $DAPPNODE_CORE_DIR -name "docker-compose-*.yml" -printf "-f %p ")
+DNCORE_YMLS_ARRAY=($(find $DAPPNODE_CORE_DIR -name "docker-compose-*.yml"))
+
 alias dappnode_status='docker-compose $DNCORE_YMLS ps'
 alias dappnode_stop='docker-compose $DNCORE_YMLS stop && docker stop $(docker container ls -a -q -f name=DAppNode*)'
 alias dappnode_start='docker-compose $DNCORE_YMLS up -d && docker start $(docker container ls -a -q -f name=DAppNode*)'


### PR DESCRIPTION
When executing `docker-compose up` against more than one compose file, these compose files must have the same compose file version (e.g 3.5), otherwise it will end up in an error.

**Fix**: execute `compose-up` independently