### PR TITLE
Add avahi

### DIFF
--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -10,7 +10,7 @@ d-i netcfg/get_domain seen true
 d-i passwd/username string dappnode
 d-i passwd/username seen false
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server vim sudo iw iwd wpasupplicant intel-microcode iucode-tool build-essential linux-headers-$(uname -r) firmware-iwlwifi avahi-daemon avahi-discover libnss-mdns
+d-i pkgsel/include string openssh-server vim sudo iw iwd wpasupplicant intel-microcode iucode-tool build-essential linux-headers-$(uname -r) firmware-iwlwifi avahi-utils
 d-i apt-setup/use_mirror boolean false
 d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org

--- a/iso/preseeds/preseed.cfg
+++ b/iso/preseeds/preseed.cfg
@@ -10,7 +10,7 @@ d-i netcfg/get_domain seen true
 d-i passwd/username string dappnode
 d-i passwd/username seen false
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server vim sudo iw iwd wpasupplicant intel-microcode iucode-tool build-essential linux-headers-$(uname -r) firmware-iwlwifi
+d-i pkgsel/include string openssh-server vim sudo iw iwd wpasupplicant intel-microcode iucode-tool build-essential linux-headers-$(uname -r) firmware-iwlwifi avahi-daemon avahi-discover libnss-mdns
 d-i apt-setup/use_mirror boolean false
 d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -55,7 +55,7 @@ d-i grub-installer/bootdev string default
 
 ### Package selection
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server vim sudo build-essential linux-headers-$(uname -r) iw iwd wpasupplicant intel-microcode iucode-tool firmware-misc-nonfree firmware-iwlwifi avahi-daemon avahi-discover libnss-mdns
+d-i pkgsel/include string openssh-server vim sudo build-essential linux-headers-$(uname -r) iw iwd wpasupplicant intel-microcode iucode-tool firmware-misc-nonfree firmware-iwlwifi avahi-utils
 d-i apt-setup/use_mirror boolean false
 d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org

--- a/iso/preseeds/preseed_unattended.cfg
+++ b/iso/preseeds/preseed_unattended.cfg
@@ -55,7 +55,7 @@ d-i grub-installer/bootdev string default
 
 ### Package selection
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server vim sudo build-essential linux-headers-$(uname -r) iw iwd wpasupplicant intel-microcode iucode-tool firmware-misc-nonfree firmware-iwlwifi
+d-i pkgsel/include string openssh-server vim sudo build-essential linux-headers-$(uname -r) iw iwd wpasupplicant intel-microcode iucode-tool firmware-misc-nonfree firmware-iwlwifi avahi-daemon avahi-discover libnss-mdns
 d-i apt-setup/use_mirror boolean false
 d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org

--- a/scripts/dappnode_access_credentials.sh
+++ b/scripts/dappnode_access_credentials.sh
@@ -25,6 +25,15 @@ DAPPNODE_WELCOME_URL="http://welcome.dappnode"
 #1.FUNCTIONS#
 #############
 
+# How to check dappnode was initialized successfully:
+# 1. docker service running
+# 2. Default timeout
+
+function dappnode_startup_delay () {
+  echo "Wait until DAppNode initializes..."
+  sleep 10
+}
+
 # $1 Connection method $2 Credentials
 function create_connection_message () {
   echo -e "\e[32mConnect to DAppNode through $1 using the following credentials:\e[0m\n$2\nVisit \e[4m$DAPPNODE_ADMINUI_URL\e\nCheck out all the access methods available to connect to your DAppNode at \e[4m$DAPPNODE_WELCOME_URL\e"
@@ -80,6 +89,7 @@ function openvpn_connection () {
 #2.MAIN#
 ########
 
+dappnode_startup_delay
 wifi_connection
 avahi_connection
 wireguard_connection


### PR DESCRIPTION
Add avahi and necessary tools to the installation process
- Avahi-daemon
- Avahi-discover: might be useful to debug the status
- libnss-mdns: might be necessary to make avahi-publish with multiple domain work