### PR TITLE
Disable access credentials option

### DIFF
--- a/scripts/dappnode_access_credentials.sh
+++ b/scripts/dappnode_access_credentials.sh
@@ -28,6 +28,7 @@ DAPPNODE_WELCOME_URL="http://welcome.dappnode"
 #############
 
 function dappnode_startup_check () {
+  [ -f "/usr/src/dappnode/.nocreds" ] && exit 0
   echo -n "Wait until DAppNode initializes (press ctrl+c to stop) "
   sleep 5
   n=0

--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -245,9 +245,7 @@ dappnode_start() {
     fi
 
     # Display credentials to the user
-    if [ -f $DAPPNODE_ACCESS_CREDENTIALS ] && [ ! -f "/usr/src/dappnode/.nocreds" ]; then
-    /bin/bash $DAPPNODE_ACCESS_CREDENTIALS
-    fi
+    [ -f $DAPPNODE_ACCESS_CREDENTIALS ] && /bin/bash $DAPPNODE_ACCESS_CREDENTIALS
 }
 
 installExtraDpkg() {

--- a/scripts/dappnode_install.sh
+++ b/scripts/dappnode_install.sh
@@ -245,7 +245,9 @@ dappnode_start() {
     fi
 
     # Display credentials to the user
-    [ -f $DAPPNODE_ACCESS_CREDENTIALS ] && /bin/bash $DAPPNODE_ACCESS_CREDENTIALS
+    if [ -f $DAPPNODE_ACCESS_CREDENTIALS ] && [ ! -f "/usr/src/dappnode/.nocreds" ]; then
+    /bin/bash $DAPPNODE_ACCESS_CREDENTIALS
+    fi
 }
 
 installExtraDpkg() {


### PR DESCRIPTION
By writing `touch /usr/src/dappnode/.nocreds` in terminal using root privileges dappnode will skip detecting access modes on every startup.